### PR TITLE
Fix module name in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-secp256k1
+module github.com/kaspanet/go-secp256k1
 
 go 1.13
 


### PR DESCRIPTION
With the current module name you get the following error:
```
go: finding module for package github.com/kaspanet/go-secp256k1
go: found github.com/kaspanet/go-secp256k1 in github.com/kaspanet/go-secp256k1 v0.0.0-20200324121421-5bc7b08fa280
go: github.com/kaspanet/kaspad/blockdag imports
        github.com/kaspanet/go-secp256k1: github.com/kaspanet/go-secp256k1@v0.0.0-20200324121421-5bc7b08fa280: parsing go.mod:
        module declares its path as: go-secp256k1
                but was required as: github.com/kaspanet/go-secp256k1
```

This is also in line with go stdlib ie: https://github.com/golang/lint/blob/16217165b5de779cb6a5e4fc81fa9c1166fda457/go.mod#L1
and kaspad: https://github.com/kaspanet/kaspad/blob/master/go.mod#L1