### PR TITLE
Add constants and implement DeserializeXXXFromSlice for all serialized objects

### DIFF
--- a/multiset.go
+++ b/multiset.go
@@ -7,6 +7,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// SerializedMultiSetSize defines the length in bytes of SerializedMultiSet
+const SerializedMultiSetSize = 64
+
 // MultiSet is a type used to create an Elliptic Curve Multiset Hash
 // which is a rolling(homomorphic) hash that you can add and remove elements from
 // and receiving the same resulting hash as-if you never hashed that element.
@@ -17,7 +20,7 @@ type MultiSet struct {
 }
 
 // SerializedMultiSet is a is a byte array representing the storage representation of a MultiSet
-type SerializedMultiSet [64]byte
+type SerializedMultiSet [SerializedMultiSetSize]byte
 
 // String returns the SerializedMultiSet as the hexadecimal string
 func (serialized *SerializedMultiSet) String() string {
@@ -113,4 +116,16 @@ func DeserializeMultiSet(serialized *SerializedMultiSet) (multiset *MultiSet, er
 		return nil, errors.New("failed parsing the multiset")
 	}
 	return
+}
+
+// DeserializeMultiSetFromSlice returns a MultiSet type from a from a a serialized multiset slice.
+// will verify that it's SerializedMultiSetSize bytes long and a valid multiset.
+func DeserializeMultiSetFromSlice(newMultiSet []byte) (multiset *MultiSet, err error) {
+	if len(newMultiSet) != SerializedMultiSetSize {
+		return nil, errors.Errorf("invalid multiset length got %d, expected %d", len(newMultiSet),
+			SerializedMultiSetSize)
+	}
+	serializedMultiSet := &SerializedMultiSet{}
+	copy(serializedMultiSet[:], newMultiSet)
+	return DeserializeMultiSet(serializedMultiSet)
 }

--- a/secp256k1.go
+++ b/secp256k1.go
@@ -44,8 +44,13 @@ func init() {
 	}
 }
 
-// HashSize of array used to store hashes. See Hash.
-const HashSize = 32
+const (
+	// HashSize of array used to store hashes. See Hash.
+	HashSize = 32
+
+	// SerializedPrivateKeySize defines the length in bytes of SerializedPrivateKey
+	SerializedPrivateKeySize = 32
+)
 
 // Hash is a type encapsulating the result of hashing some unknown sized data.
 // it typically represents Sha256 / Double Sha256.
@@ -81,11 +86,11 @@ func (hash *Hash) String() string {
 // PrivateKey is a type representing a Secp256k1 private key.
 // This private key can be used to create Schnorr/ECDSA signatures
 type PrivateKey struct {
-	privateKey [32]byte
+	privateKey [SerializedPrivateKeySize]byte
 }
 
 // SerializedPrivateKey is a byte array representing the storage representation of a PrivateKey
-type SerializedPrivateKey [32]byte
+type SerializedPrivateKey [SerializedPrivateKeySize]byte
 
 // String returns the PrivateKey as the hexadecimal string
 func (key *SerializedPrivateKey) String() string {
@@ -108,6 +113,19 @@ func DeserializePrivateKey(data *SerializedPrivateKey) (key *PrivateKey, err err
 	}
 
 	return &PrivateKey{*data}, nil
+}
+
+// DeserializePrivateKeyFromSlice returns a PrivateKey type from a serialized private key slice.
+// will verify that it's 32 byte and it's a valid private key(Group Order > key > 0)
+func DeserializePrivateKeyFromSlice(data []byte) (key *PrivateKey, err error) {
+	if len(data) != SerializedPrivateKeySize {
+		return nil, errors.Errorf("invalid private key length got %d, expected %d", len(data),
+			SerializedPrivateKeySize)
+	}
+
+	serializedKey := &SerializedPrivateKey{}
+	copy(serializedKey[:], data)
+	return DeserializePrivateKey(serializedKey)
 }
 
 // GeneratePrivateKey generates a random valid private key from `crypto/rand`

--- a/secp256k1_test.go
+++ b/secp256k1_test.go
@@ -464,17 +464,21 @@ func TestSchnorrSignatureVerify(t *testing.T) {
 		},
 	}
 
-	sig64 := SerializedSchnorrSignature{}
 	msg32 := Hash{}
 	for i, test := range tests {
 		pubkey, err := DeserializeSchnorrPubKey(test.pubKey)
 		if err != nil {
 			t.Fatal(err)
 		}
-		copy(sig64[:], test.signature)
-		sig := DeserializeSchnorrSignature(&sig64)
+		sig, err := DeserializeSchnorrSignatureFromSlice(test.signature)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-		copy(msg32[:], test.message)
+		err = msg32.SetBytes(test.message)
+		if err != nil {
+			t.Fatal(err)
+		}
 		valid := pubkey.SchnorrVerify(&msg32, sig)
 		if valid != test.valid {
 			t.Errorf("Schnorr test vector '%d' expected verification: '%t', got: '%t'", i, valid, test.valid)
@@ -484,12 +488,17 @@ func TestSchnorrSignatureVerify(t *testing.T) {
 
 func TestDeterministicSchnorrSignatureGen(t *testing.T) {
 	// Test vector from Bitcoin-ABC
-	privKeyBytes := SerializedPrivateKey{}
-	copy(privKeyBytes[:], decodeHex("12b004fff7f4b69ef8650e767f18f11ede158148b425660723b9f9a66e61f747"))
-	privKey, _ := DeserializePrivateKey(&privKeyBytes)
+
+	privKey, err := DeserializePrivateKeyFromSlice(decodeHex("12b004fff7f4b69ef8650e767f18f11ede158148b425660723b9f9a66e61f747"))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	msg := Hash{}
-	copy(msg[:], decodeHex("5255683da567900bfd3e786ed8836a4e7763c221bf1ac20ece2a5171b9199e8a"))
+	err = msg.SetBytes(decodeHex("5255683da567900bfd3e786ed8836a4e7763c221bf1ac20ece2a5171b9199e8a"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	sig, err := privKey.SchnorrSign(&msg)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Some of these existed in `ecc` (https://godoc.org/github.com/kaspanet/kaspad/ecc#pkg-constants) 
the others I thought there's too much explicit `copy` and lengths in the code and some abstractions would be nicer and better
